### PR TITLE
Update testing message for Telegram Notifier

### DIFF
--- a/notifiers/telegram.go
+++ b/notifiers/telegram.go
@@ -110,9 +110,9 @@ func (u *telegram) OnSave() error {
 	return nil
 }
 
-// OnTest will test the Twilio SMS messaging
+// OnTest will test the Telegram SMS messaging
 func (u *telegram) OnTest() error {
-	msg := fmt.Sprintf("Testing the Twilio SMS Notifier on your Statping server")
+	msg := fmt.Sprintf("Testing the Telegram Notifier on your Statping server")
 	return u.Send(msg)
 }
 


### PR DESCRIPTION
Previously, when clicking the "Test Notifier" button for Telegram notifications, a notification "Testing the Twilio SMS Notifier on your Statping server" was sent. This message incorrectly stated that the "Twilio SMS Notifier" was being used. This PR fixes the typo.