### PR TITLE
fix meta description tag always displaying a count of 0 offline services

### DIFF
--- a/core/services.go
+++ b/core/services.go
@@ -452,3 +452,14 @@ func (c *Core) CountOnline() int {
 	}
 	return amount
 }
+
+// CountOffline returns the amount of services offline
+func (c *Core) CountOffline() int {
+	amount := 0
+	for _, s := range CoreApp.Services {
+		if !s.Select().Online {
+			amount++
+		}
+	}
+	return amount
+}

--- a/core/services_test.go
+++ b/core/services_test.go
@@ -177,6 +177,11 @@ func TestCountOnline(t *testing.T) {
 	assert.True(t, amount >= 2)
 }
 
+func TestCountOffline(t *testing.T) {
+	amount := CoreApp.CountOffline()
+	assert.True(t, amount < 2)
+}
+
 func TestCreateService(t *testing.T) {
 	s := ReturnService(&types.Service{
 		Name:           "That'll do 🐢",

--- a/dev/README.md
+++ b/dev/README.md
@@ -506,6 +506,13 @@ func (c *Core) CountOnline() int
 ```
 CountOnline returns the amount of services online
 
+#### func (*Core) CountOffline
+
+```go
+func (c *Core) CountOffline() int
+```
+CountOffline returns the amount of services offline
+
 #### func (Core) CurrentTime
 
 ```go

--- a/source/tmpl/index.gohtml
+++ b/source/tmpl/index.gohtml
@@ -1,5 +1,5 @@
 {{define "title"}}{{CoreApp.Name}} Status{{end}}
-{{define "description"}}{{CoreApp.Name}} is currently monitoring {{len CoreApp.Services}} services with 0 of them offline. {{CoreApp.Name}} is using Statping to monitor applications.{{end}}
+{{define "description"}}{{CoreApp.Name}} is currently monitoring {{len CoreApp.Services}} services with {{CoreApp.CountOffline}} of them offline. {{CoreApp.Name}} is using Statping to monitor applications.{{end}}
 {{define "content"}}
 <div class="container col-md-7 col-sm-12 mt-2 sm-container">
 <h1 class="col-12 text-center mb-4 mt-sm-3 header-title">{{.Name}}</h1>


### PR DESCRIPTION
This PR adds a new function: `CountOffline` which can be used to get the count of the number of offline services.

It is used inside the `index.gohtml` template to fix the meta description tag which would always display 0 services offline despite reality.

Fix for #365 