### PR TITLE
`delete_failures` request via POST

### DIFF
--- a/core/failures.go
+++ b/core/failures.go
@@ -71,6 +71,8 @@ func (s *Service) DeleteFailures() {
 		// deleted.
 		return
 	}
+
+	log.Infof("Deleted all failures of Service with ID '%d'\n", s.Id)
 	s.Failures = nil
 }
 

--- a/core/failures.go
+++ b/core/failures.go
@@ -66,6 +66,10 @@ func (s *Service) DeleteFailures() {
 	err := DbSession.Exec(`DELETE FROM failures WHERE service = ?`, s.Id)
 	if err.Error != nil {
 		log.Errorln(fmt.Sprintf("failed to delete all failures: %v", err))
+
+		// do not set `Failures` field to null since they have not been
+		// deleted.
+		return
 	}
 	s.Failures = nil
 }

--- a/handlers/routes.go
+++ b/handlers/routes.go
@@ -109,7 +109,7 @@ func Router() *mux.Router {
 	r.Handle("/service/create", authenticated(createServiceHandler, true)).Methods("GET")
 	r.Handle("/service/{id}", http.HandlerFunc(servicesViewHandler)).Methods("GET")
 	r.Handle("/service/{id}/edit", authenticated(servicesViewHandler, true)).Methods("GET")
-	r.Handle("/service/{id}/delete_failures", authenticated(servicesDeleteFailuresHandler, true)).Methods("GET")
+	r.Handle("/service/{id}/delete_failures", authenticated(servicesDeleteFailuresHandler, true)).Methods("POST")
 
 	r.Handle("/group/{id}", http.HandlerFunc(groupViewHandler)).Methods("GET")
 

--- a/handlers/services.go
+++ b/handlers/services.go
@@ -305,6 +305,7 @@ func servicesDeleteFailuresHandler(w http.ResponseWriter, r *http.Request) {
 		sendErrorJson(errors.New("service not found"), w, r)
 		return
 	}
+
 	service.DeleteFailures()
 	sendJsonAction(service, "delete_failures", w, r)
 }

--- a/source/tmpl/form_service.gohtml
+++ b/source/tmpl/form_service.gohtml
@@ -159,7 +159,15 @@
         </div>
         {{if ne .Id 0}}
         <div class="col-6">
-            <a href="service/{{ .Id }}/delete_failures" data-method="GET" data-redirect="/service/{{ .Id }}" class="btn btn-danger btn-block confirm-btn">Delete All Failures</a>
+            <script>
+                function deleteAllFailures() {
+                        var xhttp = new XMLHttpRequest();
+                        xhttp.open("POST", "service/{{ .Id }}/delete_failures", false);
+                        xhttp.send();
+                }
+            </script>
+
+            <button onclick="deleteAllFailures()" class="btn btn-danger btn-block confirm-btn">Delete all failures</button>
         </div>
         {{end}}
     </div>


### PR DESCRIPTION
The `Delete all failures` button should call the `delete_failures` Endpoint via `POST` and not `GET`.

fixes #378 