### PR TITLE
Updated Enabling Notifications UI

### DIFF
--- a/core/checker.go
+++ b/core/checker.go
@@ -217,6 +217,7 @@ func (s *Service) checkHttp(record bool) *Service {
 	}
 	if err != nil {
 		if record {
+			s.LastStatusCode = 503
 			recordFailure(s, fmt.Sprintf("HTTP Error %v", err))
 		}
 		return s

--- a/source/tmpl/form_notifier.gohtml
+++ b/source/tmpl/form_notifier.gohtml
@@ -1,22 +1,26 @@
 {{define "form_notifier"}}
 {{$n := .Select}}
-<form class="ajax_form {{underscore $n.Method }}" data-func="SaveNotifier" action="api/notifier/{{ $n.Method }}" method="POST">
-{{if $n.Title}}<h4 class="text-capitalize">{{$n.Title}}</h4>{{end}}
-{{if $n.Description}}<p class="small text-muted">{{safe $n.Description}}</p>{{end}}
+<form class="ajax_form {{underscore $n.Method }}" data-func="SaveNotifier" action="api/notifier/{{ $n.Method }}"
+    method="POST">
+    {{if $n.Title}}<h4 class="text-capitalize">{{$n.Title}}</h4>{{end}}
+    {{if $n.Description}}<p class="small text-muted">{{safe $n.Description}}</p>{{end}}
 
-{{range $n.Form}}
+    {{range $n.Form}}
     <div class="form-group">
-            <label class="text-capitalize{{if .IsHidden}} d-none{{end}}" for="{{underscore .Title}}">{{.Title}}</label>
+        <label class="text-capitalize{{if .IsHidden}} d-none{{end}}" for="{{underscore .Title}}">{{.Title}}</label>
         {{if eq .Type "textarea"}}
-            <textarea rows="3" class="form-control{{if .IsHidden}} d-none{{end}}" name="{{underscore .DbField}}" id="{{underscore .Title}}">{{ $n.GetValue .DbField }}</textarea>
+        <textarea rows="3" class="form-control{{if .IsHidden}} d-none{{end}}" name="{{underscore .DbField}}"
+            id="{{underscore .Title}}">{{ $n.GetValue .DbField }}</textarea>
         {{else}}
-            <input type="{{.Type}}" name="{{underscore .DbField}}" class="form-control{{if .IsHidden}} d-none{{end}}" value="{{ $n.GetValue .DbField }}" id="{{underscore .Title}}" placeholder="{{.Placeholder}}" {{if .Required}}required{{end}}>
+        <input type="{{.Type}}" name="{{underscore .DbField}}" class="form-control{{if .IsHidden}} d-none{{end}}"
+            value="{{ $n.GetValue .DbField }}" id="{{underscore .Title}}" placeholder="{{.Placeholder}}"
+            {{if .Required}}required{{end}}>
         {{end}}
         {{if .SmallText}}
-            <small class="form-text text-muted{{if .IsHidden}} d-none{{end}}">{{safe .SmallText}}</small>
+        <small class="form-text text-muted{{if .IsHidden}} d-none{{end}}">{{safe .SmallText}}</small>
         {{end}}
     </div>
-{{end}}
+    {{end}}
 
     <div class="row">
         <div class="col-9 col-sm-6">
@@ -24,30 +28,18 @@
                 <div class="input-group-prepend">
                     <div class="input-group-text">Limit</div>
                 </div>
-                <input type="number" class="form-control" name="limits" min="1" max="60" id="limits_per_hour_{{underscore $n.Method }}" value="{{$n.Limits}}" placeholder="7">
+                <input type="number" class="form-control" name="limits" min="1" max="60"
+                    id="limits_per_hour_{{underscore $n.Method }}" value="{{$n.Limits}}" placeholder="7">
                 <div class="input-group-append">
                     <div class="input-group-text">Per Minute</div>
                 </div>
             </div>
         </div>
 
-        <div class="col-3 col-sm-2 mt-1">
-            <span class="switch">
-                <input type="checkbox" name="enabled-option" class="switch" id="switch-{{ $n.Method }}" {{if $n.Enabled.Bool}}checked{{end}}>
-                <label for="switch-{{ $n.Method }}"></label>
-                <input type="hidden" name="enabled" id="switch-{{ $n.Method }}-value" value="{{if $n.Enabled.Bool}}true{{else}}false{{end}}">
-            </span>
-        </div>
-
-        <input type="hidden" name="method" value="{{underscore $n.Method }}">
-
-        <div class="col-12 col-sm-4 mb-2 mb-sm-0 mt-2 mt-sm-0">
-            <button type="submit" class="btn btn-primary btn-block text-capitalize"><i class="fa fa-check-circle"></i> Save</button>
-        </div>
-
-    {{if $n.CanTest}}
-        <div class="col-12 col-sm-12">
-            <button class="test_notifier btn btn-secondary btn-block text-capitalize col-12 float-right"><i class="fa fa-vial"></i> Test Notifier</button>
+        {{if $n.CanTest}}
+        <div class="col-6 col-sm-6">
+            <button class="test_notifier btn btn-secondary btn-block text-capitalize col-12 float-right"><i
+                    class="fa fa-vial"></i> Test Notifier</button>
         </div>
 
         <div class="col-12 col-sm-12 mt-2">
@@ -59,15 +51,37 @@
                 <i class="fa fa-smile-beam"></i> The {{$n.Method}} notifier is working correctly!
             </div>
         </div>
-    {{end}}
+        {{end}}
+
+        <div class="col-3 col-sm-3 mt-1">
+            <div><h4>Enable</h4></div>
+        </div>
+
+        <div class="col-3 col-sm-3 mt-1">
+            <span class="switch">
+                <input type="checkbox" name="enabled-option" class="switch" id="switch-{{ $n.Method }}"
+                    {{if $n.Enabled.Bool}}checked{{end}}>
+                <label for="switch-{{ $n.Method }}"></label>
+                <input type="hidden" name="enabled" id="switch-{{ $n.Method }}-value"
+                    value="{{if $n.Enabled.Bool}}true{{else}}false{{end}}">
+            </span>
+        </div>
+
+        <input type="hidden" name="method" value="{{underscore $n.Method }}">
+
+        <div class="col-6 col-sm-6 mb-2 mb-sm-0 mt-2 mt-sm-0">
+            <button type="submit" class="btn btn-primary btn-block text-capitalize"><i class="fa fa-check-circle"></i>
+                Save</button>
+        </div>
 
     </div>
 
-{{if $n.Author}}
+    {{if $n.Author}}
     <span class="d-block small text-center mt-3 mb-5">
-        <span class="text-capitalize">{{$n.Title}}</span> Notifier created by <a href="{{$n.AuthorUrl}}" target="_blank">{{$n.Author}}</a>
-                        </span>
-{{ end }}
+        <span class="text-capitalize">{{$n.Title}}</span> Notifier created by <a href="{{$n.AuthorUrl}}"
+            target="_blank">{{$n.Author}}</a>
+    </span>
+    {{ end }}
     <div class="alert alert-danger d-none" id="alerter" role="alert"></div>
 </form>
 {{end}}


### PR DESCRIPTION
I recently misunderstood the UI for enabling specific notifications (https://github.com/hunterlong/statping/issues/314) so I updated the UI slightly to make it more obvious. Let me know what you think.

Current UI:
![old_enable](https://user-images.githubusercontent.com/5089723/75251145-ee89a180-57d1-11ea-8dfb-2b1e3012ee9b.png)


Proposed UI:
![new_enable](https://user-images.githubusercontent.com/5089723/75251164-f77a7300-57d1-11ea-8a55-97ec2944cb33.png)
Thanks