### PR TITLE
Fixed current id of in use service not being properly set, fixes #514

### DIFF
--- a/frontend/src/components/Dashboard/Incidents.vue
+++ b/frontend/src/components/Dashboard/Incidents.vue
@@ -52,52 +52,56 @@ import Api from "../../API";
 import FormIncidentUpdates from "@/forms/IncidentUpdates";
 
 export default {
-    name: 'Incidents',
+  name: 'Incidents',
   components: {FormIncidentUpdates},
   data() {
-        return {
-            service_id: 0,
-              ready: false,
-              incidents: [],
-              incident: {
-                title: "",
-                description: "",
-                service: 0,
-              }
-        }
-    },
-  computed:{
-    theID() {
-      return this.$route.params.id
-    }
-  },
-  async mounted() {
-    await this.loadIncidents()
-  },
-  methods: {
-      async getIncidents() {
-        return await Api.incidents_service(this.theID)
-      },
-      async deleteIncident(incident) {
-        let c = confirm(`Are you sure you want to delete '${incident.title}'?`)
-        if (c) {
-          await Api.incident_delete(incident)
-          await this.loadIncidents()
-        }
-      },
-      async loadIncidents() {
-        this.incidents = await Api.incidents_service(this.service_id)
-      },
-      async createIncident() {
-        await Api.incident_create(this.theID, this.incident)
-        await this.loadIncidents()
-        this.incident = {
-          title: "",
-          description: "",
-          service: this.service_id,
-        }
+      return {
+          serviceID: 0,
+          incidents: [],
+          incident: {
+              title: "",
+              description: "",
+              service: 0,
+          },
       }
-    }
+  },
+
+  created() {
+      this.serviceID = Number(this.$route.params.id);
+      this.incident.service = Number(this.$route.params.id);
+  },
+
+  async mounted() {
+      await this.loadIncidents()
+  },
+
+  methods: {
+      //async getIncidents() {
+      //    return await Api.incidents_service(this.serviceID)
+      //},
+
+      async deleteIncident(incident) {
+          let c = confirm(`Are you sure you want to delete '${incident.title}'?`)
+          if (c) {
+              await Api.incident_delete(incident)
+              await this.loadIncidents()
+          }
+      },
+
+      async loadIncidents() {
+          this.incidents = await Api.incidents_service(this.serviceID)
+      },
+
+      async createIncident() {
+          await Api.incident_create(this.serviceID, this.incident)
+          await this.loadIncidents()
+          this.incident = {
+              title: "",
+              description: "",
+              service: this.serviceID,
+          }
+      }
+  }
 }
 </script>
 


### PR DESCRIPTION
The service id is initially set as 0, there was some functionality to get current id of 'selected' service but was not fully being utilised by all methods.

### Changes Overview

On creation of the view, we get the id from the route param that was sent to the view and then update or data obj to that id, we also set the id inside of the obj strut used to create the incident as but default it is also 0. Subsequent incidents obj are re-update as per the existing code logic but using the new variable _this.serviceID_, incidents are also loaded using this.


FYI:
Also I don't see _getIncidents()_ being used, nothing broke as far as I could tell, so I left it commented out, perhaps remove for code clean up if defo not being used.