### PR TITLE
Add missing volume declaration in docker-compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Upcoming
+- Fixed incomplete Alert mail ([#471](https://github.com/statping/statping/issues/472))
+
 # 0.90.33 (04-24-2020)
 - Fixed config loading method
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 version: '2.3'
 
 services:
-
   statping:
     container_name: statping
     image: statping/statping:latest
@@ -12,3 +11,6 @@ services:
       DB_CONN: sqlite
     ports:
       - 8080:8080
+
+volumes:
+  statping_data:

--- a/utils/replacer.go
+++ b/utils/replacer.go
@@ -2,32 +2,23 @@ package utils
 
 import (
 	"bytes"
-	"fmt"
 	"text/template"
 )
 
 func ReplaceTemplate(tmpl string, data interface{}) string {
 	buf := new(bytes.Buffer)
-	var varStr string
-	switch fmt.Sprintf("%T", data) {
-	case "*services.Service":
-		varStr = "Service"
-	case "*failures.Failure":
-		varStr = "Failure"
-	default:
-		varStr = "Object"
-	}
-	injectVars := make(map[string]interface{})
-	injectVars[varStr] = data
+
 	slackTemp, err := template.New("replacement").Parse(tmpl)
 	if err != nil {
 		Log.Error(err)
 		return err.Error()
 	}
-	err = slackTemp.Execute(buf, injectVars)
+
+	err = slackTemp.Execute(buf, data)
 	if err != nil {
 		Log.Error(err)
 		return err.Error()
 	}
+
 	return buf.String()
 }


### PR DESCRIPTION
When running `docker-compose up -d` then docker-compose complains that the `statping_data` was not declared.

This PR declares the `statping_data` volume in `docker-compose.yaml`.