### PR TITLE
Add missing volume declaration in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 version: '2.3'
 
 services:
-
   statping:
     container_name: statping
     image: statping/statping:latest
@@ -12,3 +11,6 @@ services:
       DB_CONN: sqlite
     ports:
       - 8080:8080
+
+volumes:
+  statping_data:


### PR DESCRIPTION
When running docker-compose up -d then docker-compose complains that the statping_data was not declared.

This PR declares the statping_data volume in docker-compose.yaml.