### PR TITLE
Fix Mail notification Template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Upcoming
+- Added missing information to Mail notification ([#472](https://github.com/statping/statping/issues/472))
+
 # 0.90.33 (04-24-2020)
 - Fixed config loading method
 

--- a/utils/replacer.go
+++ b/utils/replacer.go
@@ -2,32 +2,23 @@ package utils
 
 import (
 	"bytes"
-	"fmt"
 	"text/template"
 )
 
 func ReplaceTemplate(tmpl string, data interface{}) string {
 	buf := new(bytes.Buffer)
-	var varStr string
-	switch fmt.Sprintf("%T", data) {
-	case "*services.Service":
-		varStr = "Service"
-	case "*failures.Failure":
-		varStr = "Failure"
-	default:
-		varStr = "Object"
-	}
-	injectVars := make(map[string]interface{})
-	injectVars[varStr] = data
+
 	slackTemp, err := template.New("replacement").Parse(tmpl)
 	if err != nil {
 		Log.Error(err)
 		return err.Error()
 	}
-	err = slackTemp.Execute(buf, injectVars)
+
+	err = slackTemp.Execute(buf, data)
 	if err != nil {
 		Log.Error(err)
 		return err.Error()
 	}
+
 	return buf.String()
 }


### PR DESCRIPTION
The Email notifier template didn't worked as expected.

The Mail will now look like this (added missing information):
![Screenshot_20200427_134639](https://user-images.githubusercontent.com/29659953/80368798-97658300-888d-11ea-9ca7-d2f36b203a20.png)

@hunterlong I've added `# Upcoming` to the `CHANGELOG.md` so its possible to keep track of the changes which has been made. If you don't want the `Upcoming` section in `CHANGELOG.md` let me know and I will remove the commit.

Closes #472 
