### PR TITLE
explicit @babel/preset-env =7.9.0

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -49,7 +49,7 @@
     "@babel/plugin-syntax-dynamic-import": "~7.2",
     "@babel/plugin-syntax-import-meta": "~7.2",
     "@babel/polyfill": "~7.2",
-    "@babel/preset-env": "^7.9.0",
+    "@babel/preset-env": "=7.9.0",
     "@vue/babel-preset-app": "^4.1.2",
     "@vue/cli-plugin-babel": "^4.1.0",
     "@vue/cli-service": "^4.2.3",


### PR DESCRIPTION
I got error when `yarn build`
```ERROR in ./src/main.js
Module build failed (from ./node_modules/babel-loader/lib/index.js):
Error: [BABEL] /Users/nhanvt/projects/statping/frontend/src/main.js: Cannot find module '@babel/compat-data/corejs3-shipped-proposals'
```
This pull request is for explicit version of `@babel/preset-env = 7.9.0` and we can build frontend code again.