### PR TITLE
Fixes #568: Service links should use permalinks when possible

### DIFF
--- a/frontend/src/mixin.js
+++ b/frontend/src/mixin.js
@@ -74,7 +74,7 @@ export default Vue.mixin({
     },
     serviceLink(service) {
       if (service.permalink) {
-        service = this.$store.getters.serviceByPermalink(service)
+        service = this.$store.getters.serviceByPermalink(service.permalink)
       }
       if (service===undefined) {
         return `/service/0`


### PR DESCRIPTION
serviceByPermalink expects a permalink value, not the whole service