### PR TITLE
docker compose stack updates

### DIFF
--- a/dev/docker-compose.full.yml
+++ b/dev/docker-compose.full.yml
@@ -1,73 +1,42 @@
 version: '2.3'
 
+
+###############################################
+#            Statping Full Stack
+#
+#  Statping SQLIte =>   http://localhost:8080
+#  Statping MySQL =>    http://localhost:8081
+#  Statping Postgres => http://localhost:8082
+#  Statping MariaDB =>  http://localhost:8083
+#
+#  Adminer        =>    http://localhost:8282
+#  Prometheus     =>    http://localhost:7050
+#  Grafana        =>    http://localhost:3000
+#
+###############################################
+
 services:
 
-  nginx-proxy:
-    image: jwilder/nginx-proxy
-    ports:
-      - 80:80
-    volumes:
-      - /var/run/docker.sock:/tmp/docker.sock:ro
-    networks:
-      - statping
-
-#  statping_dev:
-#    container_name: statping_dev
-#    build:
-#      context: .
-#      dockerfile: ./dev/Dockerfile.dev
-#      args:
-#        VERSION: DEV
-#        COMMIT: DEV
-#    restart: on-failure
-#    volumes:
-#      - ./:/go/src/github.com/statping/statping
-#    environment:
-#      VIRTUAL_HOST: local.statping.com
-#      VIRTUAL_PORT: 8888
-#      GO_ENV: test
-#      DB_CONN: sqlite
-#      API_SECRET: exampleapisecret
-#      NAME: Statping on SQLite
-#      DOMAIN: http://localhost:4000
-#      DESCRIPTION: This is a dev environment on SQLite!
-#      ADMIN_USER: admin
-#      ADMIN_PASS: admin
-#      PORT: 8585
-#      SERVICES: '[{"name": "Local Statping", "type": "http", "domain": "http://localhost:8585", "interval": 30}]'
-#    ports:
-#      - 8888:8888
-#      - 8585:8585
-#    networks:
-#      - statping
-#    healthcheck:
-#      test: ["CMD-SHELL", "curl -f http://localhost:8585/health || false"]
-#      timeout: 2s
-#      interval: 20s
-#      retries: 30
-
-  statping:
-    container_name: statping
+  statping_sqlite:
+    container_name: statping_sqlite
     build:
-      context: ./
+      context: ../
     restart: on-failure
     volumes:
       - ./docker/statping/sqlite:/app
     environment:
-      SERVICES: '[{"name": "Local Statping", "type": "http", "domain": "http://localhost:8585", "interval": 30}]'
-      VIRTUAL_HOST: sqlite.dev.statping.com
-      VIRTUAL_PORT: 8080
       DB_CONN: sqlite
       API_SECRET: exampleapisecret
-      NAME: Statping on SQLite
-      DOMAIN: http://localhost:4000
+      NAME: Statping
+      DOMAIN: http://localhost:8080
       DESCRIPTION: This is a dev environment on SQLite!
       ADMIN_USER: admin
       ADMIN_PASS: admin
     ports:
-      - 4000:8080
+      - 8080:8080
     networks:
-      - statping
+      - database
+      - frontend
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:8080/health || false"]
       timeout: 2s
@@ -77,88 +46,118 @@ services:
   statping_mysql:
     container_name: statping_mysql
     build:
-      context: ./
+      context: ../
     restart: on-failure
-    ports:
-      - 4005:8080
     volumes:
       - ./docker/statping/mysql:/app
-    links:
-      - mysql
     environment:
-      VIRTUAL_HOST: mysql.dev.statping.com
-      VIRTUAL_PORT: 8080
       DB_CONN: mysql
       DB_HOST: mysql
-      DB_PORT: 3306
-      DB_DATABASE: statping
       DB_USER: root
       DB_PASS: password123
+      DB_DATABASE: statping
+      DB_PORT: 3306
       API_SECRET: exampleapisecret
-      NAME: Statping on MySQL
-      DOMAIN: http://localhost:4005
+      NAME: Statping MySQL
+      DOMAIN: http://localhost:8080
       DESCRIPTION: This is a dev environment on MySQL!
       ADMIN_USER: admin
       ADMIN_PASS: admin
+    ports:
+      - 8081:8080
     networks:
-      - statping
-    depends_on:
-      mysql:
-        condition: service_healthy
+      - database
+      - frontend
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:8080/health || false"]
       timeout: 2s
       interval: 10s
       retries: 20
+    depends_on:
+      mysql:
+        condition: service_healthy
 
   statping_postgres:
     container_name: statping_postgres
     build:
-      context: ./
+      context: ../
     restart: on-failure
-    ports:
-      - 4010:8080
     volumes:
-      - ./docker/statping/postgres:/app
-    links:
-      - postgres
+      - ./docker/statping/mysql:/app
     environment:
-      VIRTUAL_HOST: postgres.dev.statping.com
-      VIRTUAL_PORT: 8080
       DB_CONN: postgres
       DB_HOST: postgres
-      DB_PORT: 5432
-      DB_DATABASE: statping
       DB_USER: root
       DB_PASS: password123
+      DB_DATABASE: statping
+      DB_PORT: 5432
       API_SECRET: exampleapisecret
-      NAME: Statping on Postgres
-      DOMAIN: http://localhost:4010
+      NAME: Statping Postgres
+      DOMAIN: http://localhost:8080
       DESCRIPTION: This is a dev environment on Postgres!
       ADMIN_USER: admin
       ADMIN_PASS: admin
+    ports:
+      - 8082:8080
     networks:
-      - statping
+      - database
+      - frontend
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8080/health || false"]
+      timeout: 2s
+      interval: 10s
+      retries: 20
     depends_on:
       postgres:
         condition: service_healthy
+
+  statping_mariadb:
+    container_name: statping_mariadb
+    build:
+      context: ../
+    restart: on-failure
+    volumes:
+      - ./docker/statping/mariadb:/app
+    environment:
+      DB_CONN: mysql
+      DB_HOST: mariadb
+      DB_USER: root
+      DB_PASS: password123
+      DB_DATABASE: statping
+      DB_PORT: 3306
+      API_SECRET: exampleapisecret
+      NAME: Statping MariaDB
+      DOMAIN: http://localhost:8080
+      DESCRIPTION: This is a dev environment on MariaDB!
+      ADMIN_USER: admin
+      ADMIN_PASS: admin
+    ports:
+      - 8083:8080
+    networks:
+      - database
+      - frontend
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:8080/health || false"]
-      timeout: 5s
-      interval: 5s
-      retries: 30
+      timeout: 2s
+      interval: 10s
+      retries: 20
+    depends_on:
+      mariadb:
+        condition: service_healthy
 
   postgres:
     container_name: postgres
     image: postgres
     volumes:
       - ./docker/databases/postgres:/var/lib/postgresql/data
+    ports:
+      - 5432:5432
     environment:
       POSTGRES_PASSWORD: password123
       POSTGRES_DB: statping
       POSTGRES_USER: root
     networks:
-      - statping
+      - database
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U root"]
       interval: 15s
@@ -175,95 +174,59 @@ services:
       MYSQL_ROOT_PASSWORD: password123
       MYSQL_DATABASE: statping
       MYSQL_USER: root
-      MYSQL_PASSWORD: password
+      MYSQL_PASSWORD: password123
+    ports:
+      - 3306:3306
     networks:
-      - statping
+      - database
     healthcheck:
       test: [ "CMD", "mysqladmin" ,"ping", "-h", "localhost" ]
       timeout: 20s
       interval: 15s
       retries: 30
 
-  phpmyadmin:
-    container_name: phpmyadmin
-    image: phpmyadmin/phpmyadmin
-    restart: on-failure
-    depends_on:
-      mysql:
-        condition: service_healthy
-    ports:
-      - 5050:80
-    links:
-      - mysql:db
-    environment:
-      VIRTUAL_HOST: phpmyadmin.statping.com
-      VIRTUAL_PORT: 80
-      MYSQL_ROOT_PASSWORD: password123
-      PMA_HOST: mysql
-      PMA_USER: root
-      PMA_PASSWORD: password123
-      PMA_PORT: 3306
-    networks:
-      - statping
-
-  sqlite-web:
-    container_name: sqlite-web
-    image: coleifer/sqlite-web
-    restart: on-failure
-    command: sqlite_web -H 0.0.0.0 -r -x /data/statping.db
-    depends_on:
-      statping:
-        condition: service_healthy
-    ports:
-      - 6050:8080
-    links:
-      - statping
+  mariadb:
+    container_name: mariadb
+    image: mariadb
     volumes:
-      - ./docker/statping/sqlite/statping.db:/data/statping.db:ro
+      - ./docker/databases/mariadb:/var/lib/mysql
+    restart: always
     environment:
-      VIRTUAL_HOST: sqladmin.statping.com
-      VIRTUAL_PORT: 8080
-      SQLITE_DATABASE: /data/statping.db
-    networks:
-      - statping
-
-  pgadmin4:
-    container_name: pgadmin4
-    image: fenglc/pgadmin4
-    restart: on-failure
-    environment:
-      VIRTUAL_HOST: pgadmin.statping.com
-      VIRTUAL_PORT: 5050
-      DEFAULT_USER: admin@admin.com
-      DEFAULT_PASSWORD: admin
-    depends_on:
-      postgres:
-        condition: service_healthy
+      MYSQL_ROOT_PASSWORD: password123
+      MYSQL_DATABASE: statping
+      MYSQL_USER: root
+      MYSQL_PASSWORD: password123
     ports:
-      - 7000:5050
-    links:
-      - postgres:postgres
+      - 3307:3306
     networks:
-      - statping
+      - database
+    healthcheck:
+      test: [ "CMD", "mysqladmin" ,"ping", "-h", "localhost" ]
+      timeout: 20s
+      interval: 15s
+      retries: 30
+
+  adminer:
+    container_name: adminer
+    image: adminer
+    restart: always
+    networks:
+      - database
+      - frontend
+    ports:
+      - 8282:8080
 
   prometheus:
     container_name: prometheus
     image: prom/prometheus:v2.0.0
     restart: on-failure
     volumes:
-      - ./dev/prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
       - ./docker/databases/prometheus:/prometheus
-    links:
-      - statping
-      - statping_mysql
-      - statping_postgres
     ports:
       - 7050:9090
     networks:
-      - statping
-    environment:
-      VIRTUAL_HOST: prometheus.statping.com
-      VIRTUAL_PORT: 9090
+      - database
     healthcheck:
       test: "/bin/wget -q -Y off http://localhost:9090/status -O /dev/null > /dev/null 2>&1"
       interval: 10s
@@ -277,25 +240,23 @@ services:
       - 3000:3000
     volumes:
       - ./docker/grafana:/var/lib/grafana
-      - ./dev/grafana/datasource.yml:/etc/grafana/provisioning/datasources/datasource.yml
-      - ./dev/grafana/dashboard.yml:/etc/grafana/provisioning/dashboards/dashboard.yml
-      - ./dev/grafana/statping_dashboard.json:/etc/grafana/provisioning/dashboards/statping_dashboard.json
+      - ./grafana/datasource.yml:/etc/grafana/provisioning/datasources/datasource.yml
+      - ./grafana/dashboard.yml:/etc/grafana/provisioning/dashboards/dashboard.yml
+      - ./grafana/statping_dashboard.json:/etc/grafana/provisioning/dashboards/statping_dashboard.json
     environment:
-      - VIRTUAL_HOST=grafana.statping.com
-      - VIRTUAL_PORT=3000
       - GF_USERS_ALLOW_SIGN_UP=false
       - GF_AUTH_ANONYMOUS_ENABLED=true
     depends_on:
       prometheus:
         condition: service_healthy
-    links:
-      - prometheus
     networks:
-      - statping
+      - frontend
+      - database
     healthcheck:
       test: "/usr/bin/wget -q -Y off http://localhost:3000/api/health -O /dev/null > /dev/null 2>&1"
       interval: 10s
       retries: 20
 
 networks:
-  statping:
+  frontend:
+  database:

--- a/dev/grafana/grafana.ini
+++ b/dev/grafana/grafana.ini
@@ -1,7 +1,10 @@
 [users]
 # disable user signup / registration
 allow_sign_up = false
+viewers_can_edit = true
+editors_can_admin = true
 
 [auth.anonymous]
 # enable anonymous access
 enabled = true
+

--- a/dev/grafana/statping_dashboard.json
+++ b/dev/grafana/statping_dashboard.json
@@ -558,24 +558,14 @@
   "templating": {
     "list": [
       {
-        "allValue": null,
-        "current": {},
-        "datasource": "${DS_PROMETHEUS}",
         "hide": 0,
-        "includeAll": false,
-        "label": "service",
-        "multi": false,
-        "name": "service",
+        "label": "datasource",
+        "name": "DS_PROMETHEUS",
         "options": [],
-        "query": "label_values(statup_service_latency, name)",
+        "query": "prometheus",
         "refresh": 1,
         "regex": "",
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
+        "type": "datasource"
       }
     ]
   },

--- a/dev/prometheus.yml
+++ b/dev/prometheus.yml
@@ -3,17 +3,11 @@ global:
   evaluation_interval: 15s
 
 scrape_configs:
-  - job_name: 'statping_local'
-    scrape_interval: 15s
-    bearer_token: 'samplesecret'
-    static_configs:
-      - targets: ['docker0:8585']
-
-  - job_name: 'statping'
+  - job_name: 'statping_sqlite'
     scrape_interval: 15s
     bearer_token: 'exampleapisecret'
     static_configs:
-      - targets: ['statping:8080']
+      - targets: ['statping_sqlite:8080']
 
   - job_name: 'statping_mysql'
     scrape_interval: 15s
@@ -21,14 +15,14 @@ scrape_configs:
     static_configs:
       - targets: ['statping_mysql:8080']
 
+  - job_name: 'statping_mariadb'
+    scrape_interval: 15s
+    bearer_token: 'exampleapisecret'
+    static_configs:
+      - targets: ['statping_mariadb:8080']
+
   - job_name: 'statping_postgres'
     scrape_interval: 15s
     bearer_token: 'exampleapisecret'
     static_configs:
       - targets: ['statping_postgres:8080']
-
-  - job_name: 'statping_dev'
-    scrape_interval: 15s
-    bearer_token: 'exampleapisecret'
-    static_configs:
-      - targets: ['statping_dev:8585']


### PR DESCRIPTION
Update to Statping's full stack docker-compose environment. 

- SQLite, MySQL, MariaDB and Postgres Statping instances
- Prometheus
- Grafana with auto inserted Statping dashboard
- Adminer database UI

To run the full stack, run this command in the statping directory.

```sh
docker-compose -f dev/docker-compose.full.yml up --remove-orphans --build
```