### PR TITLE
changed to ADMIN_PASSWORD rather than ~ADMIN_PASS~

### DIFF
--- a/dev/docker-compose.full.yml
+++ b/dev/docker-compose.full.yml
@@ -36,7 +36,7 @@ services:
       DOMAIN: http://localhost:8080
       DESCRIPTION: This is a dev environment on SQLite!
       ADMIN_USER: admin
-      ADMIN_PASS: admin
+      ADMIN_PASSWORD: admin
       SAMPLE_DATA: 'false'
     ports:
       - 8080:8080
@@ -69,7 +69,7 @@ services:
       DOMAIN: http://localhost:8081
       DESCRIPTION: This is a dev environment on MySQL!
       ADMIN_USER: admin
-      ADMIN_PASS: admin
+      ADMIN_PASSWORD: admin
       SAMPLE_DATA: 'false'
     ports:
       - 8081:8080
@@ -105,7 +105,7 @@ services:
       DOMAIN: http://localhost:8082
       DESCRIPTION: This is a dev environment on Postgres!
       ADMIN_USER: admin
-      ADMIN_PASS: admin
+      ADMIN_PASSWORD: admin
       SAMPLE_DATA: 'false'
     ports:
       - 8082:8080
@@ -141,7 +141,7 @@ services:
       DOMAIN: http://localhost:8083
       DESCRIPTION: This is a dev environment on MariaDB!
       ADMIN_USER: admin
-      ADMIN_PASS: admin
+      ADMIN_PASSWORD: admin
       SAMPLE_DATA: 'false'
     ports:
       - 8083:8080

--- a/dev/docker-compose.lite.yml
+++ b/dev/docker-compose.lite.yml
@@ -24,7 +24,7 @@ services:
       DOMAIN: http://localhost:8585
       DESCRIPTION: This is a dev environment with auto reloading!
       ADMIN_USER: admin
-      ADMIN_PASS: admin
+      ADMIN_PASSWORD: admin
       PORT: 8585
     ports:
       - 8888:8888

--- a/dev/pwd-stack.yml
+++ b/dev/pwd-stack.yml
@@ -18,7 +18,7 @@ services:
       DOMAIN: http://localhost:8080
       DESCRIPTION: This is a dev environment on SQLite!
       ADMIN_USER: admin
-      ADMIN_PASS: admin
+      ADMIN_PASSWORD: admin
 
   postgres:
     hostname: postgres

--- a/types/configs/load.go
+++ b/types/configs/load.go
@@ -62,7 +62,7 @@ func LoadConfigFile(configFile string) (*DbConfig, error) {
 		Domain:      p.GetString("DOMAIN"),
 		Email:       p.GetString("EMAIL"),
 		Username:    p.GetString("ADMIN_USER"),
-		Password:    p.GetString("ADMIN_PASS"),
+		Password:    p.GetString("ADMIN_PASSWORD"),
 		Location:    utils.Directory,
 		SqlFile:     p.GetString("SQL_FILE"),
 	}


### PR DESCRIPTION
Fixed the confusion... 

Use `ADMIN_PASSWORD`, Not ~ADMIN_PASS~ as an environment variable for setting a default password. Default login is still `admin`, `admin`. 