### PR TITLE
fix create/edit services

### DIFF
--- a/frontend/src/components/Dashboard/EditService.vue
+++ b/frontend/src/components/Dashboard/EditService.vue
@@ -1,23 +1,47 @@
 <template>
-    <div class="col-12">
-        <FormService :in_service="service"/>
+
+    <div v-if='ready'>
+
+        <div v-if='errorCode==404' class="col-12">
+           <div class="alert alert-warning" role="alert">
+                Service {{ this.$route.params.id }} not found!
+                <router-link v-if="$store.state.admin" to="/dashboard/create_service" class="btn btn-sm btn-outline-success float-right">
+                    <font-awesome-icon icon="plus"/>  Create One?
+                </router-link>
+            </div>
+        </div>
+
+        <div v-else-if='errorCode==401' class="col-12">
+           <div class="alert alert-danger" role="alert">
+                Unauthorized! Perhaps your session has expired?
+            </div>
+        </div>
+
+        <div v-else class="col-12">
+            <FormService :in_service="service"/>
+        </div>
+
     </div>
+    <div v-else>
+
+      <div class="text-center">
+        <div class="spinner-border text-primary" role="status">
+          <span class="sr-only">Loading...</span>
+        </div>
+      </div>
+
+    </div>
+
 </template>
 
 <script>
-  import FormGroup from "../../forms/Group";
-  import Api from "../../API";
-  import ToggleSwitch from "../../forms/ToggleSwitch";
-  import draggable from 'vuedraggable'
-  import FormService from "../../forms/Service";
+  import Api from "@/API";
+  import FormService from "@/forms/Service";
 
   export default {
   name: 'EditService',
   components: {
     FormService,
-    ToggleSwitch,
-    FormGroup,
-    draggable
   },
   props: {
 
@@ -25,23 +49,99 @@
   data () {
     return {
       ready: false,
-      service: {}
+      errorCode: 'none',
+      service: {
+          name: "",
+          type: "http",
+          domain: "",
+          group_id: 0,
+          method: "GET",
+          post_data: "",
+          headers: "",
+          expected: "",
+          expected_status: 200,
+          port: 80,
+          check_interval: 60,
+          timeout: 15,
+          permalink: "",
+          order: 1,
+          verify_ssl: true,
+          redirect: true,
+          allow_notifications: true,
+          notify_all_changes: true,
+          notify_after: 2,
+          public: true,
+          tls_cert: "",
+          tls_cert_key: "",
+          tls_cert_root: "",
+      },
     }
   },
-  computed: {
 
+
+  // because route changes within the same component are re-used
+
+  watch: {
+    $route(to, from) {
+      this.errorCode = 'none';
+      this.ready = true;
+    }
   },
-  async beforeCreate() {
+
+  // beforeCreated() causes sync issues with mounted() as they are executed
+  // one after the other regardless of async/await methods inside.
+
+  mounted() {
+
     const id = this.$route.params.id
+
     if (id) {
-      this.service = await Api.service(id)
-    }
-    this.ready = true
-  },
-  beforeMount() {
+      
+      this.loadService(id);
+
+    } else {
+
+      this.errorCode = 'none';
+      this.ready = true;
+
+    };
 
   },
+
   methods: {
+
+    async loadService(id){
+
+	this.ready = false;
+
+        // api still responds if session is invalid
+        // specifically, if statping is restarted and an existing session exists
+        // theres a further check to not display the data in the form component it seems ??
+
+        await Api.service(id).then(
+          response => {
+              this.service = response;
+              this.errorCode = 'none';
+              this.ready = true;
+          },
+          error => {
+
+              const respStatus = error.response.status;
+
+              if ( respStatus == '404' ) {
+                  this.errorCode = 404;
+              } else if ( respStatus == '401' ) {
+                   this.errorCode = 401 ;
+              } else {
+                  this.errorCode = 'none';
+              };
+
+              this.ready = true;
+
+          }
+      );
+
+    }
 
   }
 }


### PR DESCRIPTION
Fixes issues with the services not being able to create/edit, had to restructure some things and removed a bunch of 'bloat' that as far as I can see isn't doing anything, maybe left over from previous functionality?

Added a check and helper message in case the user tries to navigate to a service ID that doesn't exist:

![image](https://user-images.githubusercontent.com/7586743/83174581-7f925080-a112-11ea-8134-1223900986ee.png)

Also added a loader that is tied to the ready state (while it waits for api to respond), this prevents showing the next html blobs has they also need a check from the API response, so display the loader until that next decision can be made...

A few visual bugs exist I the component for the form for the services, seems there are functions for it define but not created, or was it previously handled by a extension/library ??

Also, for whatever reason it still returns a 404, not sure where that is coming from... but hey it works :)

FYI: the root problem was that it was sending a empty {} service object to the form component, while there is a predefined template in the Form, it would be overwritten by this empty object 😱 so there would be no data for the form to render upon...

fix #581, fix #608, fix #615
