### PR TITLE
separate command options and option arguments

### DIFF
--- a/utils/utils_custom.go
+++ b/utils/utils_custom.go
@@ -4,9 +4,9 @@ package utils
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"syscall"
 )
@@ -41,7 +41,7 @@ func Ping(address string, secondsTimeout int) error {
 	if err != nil {
 		return err
 	}
-	out, _, err := Command(ping, address, "-c 1", fmt.Sprintf("-W %v", secondsTimeout))
+	out, _, err := Command(ping, address, "-c", "1", "-W", strconv.Itoa(secondsTimeout))
 	if err != nil {
 		return err
 	}

--- a/utils/utils_windows.go
+++ b/utils/utils_windows.go
@@ -2,9 +2,9 @@ package utils
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 )
 
@@ -30,7 +30,7 @@ func Ping(address string, secondsTimeout int) error {
 	if err != nil {
 		return err
 	}
-	out, _, err := Command(ping, address, "-n 1", fmt.Sprintf("-w %v", secondsTimeout*1000))
+	out, _, err := Command(ping, address, "-n", "1", "-w", strconv.Itoa(secondsTimeout*1000))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Currently ping is run as `ping 'address' '-c 1' '-W 15'`. Some versions of the ping utility, for example the alpine Docker image and my Windows machine, are unable to parse these arguments.

This runs the command as `ping 'address' '-c' '1' '-W' '15'`, which is more correct.

Fixes #602