### PR TITLE
Fix time conversion in overview and charts

### DIFF
--- a/frontend/src/components/Service/AdvancedChart.vue
+++ b/frontend/src/components/Service/AdvancedChart.vue
@@ -131,9 +131,9 @@
                 const dt = new Date(ts).toLocaleDateString("en-us", timeoptions)
                 let val = series[seriesIndex][dataPointIndex];
                 if (val >= 1000) {
-                  val = (val * 0.1).toFixed(0) + " milliseconds"
+                  val = (val / 1000).toFixed(0) + " milliseconds"
                 } else {
-                  val = (val * 0.01).toFixed(0) + " microseconds"
+                  val = (val).toFixed(0) + " microseconds"
                 }
                 return `<div class="chartmarker"><span>Response Time: </span><span class="font-3">${val}</span><span>${dt}</span></div>`
               },

--- a/frontend/src/components/Service/ServiceSparkLine.vue
+++ b/frontend/src/components/Service/ServiceSparkLine.vue
@@ -56,9 +56,9 @@
             const dt = new Date(ts).toLocaleDateString("en-us", timeoptions)
             let val = series[seriesIndex][dataPointIndex];
             if (val >= 1000) {
-              val = (val * 0.1).toFixed(0) + " milliseconds"
+              val = (val / 1000).toFixed(0) + " milliseconds"
             } else {
-              val = (val * 0.01).toFixed(0) + " microseconds"
+              val = (val).toFixed(0) + " microseconds"
             }
             return `<div class="chartmarker"><span>Average Response Time: </span><span class="font-3">${val}</span><span>${dt}</span></div>`
           },

--- a/frontend/src/mixin.js
+++ b/frontend/src/mixin.js
@@ -166,10 +166,10 @@ export default Vue.mixin({
       return {data: newSet}
     },
     humanTime(val) {
-      if (val >= 10000) {
-          return Math.floor(val / 10000) + "ms"
+      if (val >= 1000) {
+          return Math.floor(val / 1000) + "ms"
       }
-        return Math.floor(val / 1000) + "μs"
+        return Math.floor(val) + "μs"
     },
     firstDayOfMonth(date) {
       return startOfMonth(date)

--- a/frontend/src/pages/Service.vue
+++ b/frontend/src/pages/Service.vue
@@ -270,9 +270,9 @@ export default {
                         const dt = new Date(ts).toLocaleDateString("en-us", timeoptions)
                         let val = series[seriesIndex][dataPointIndex];
                         if (val >= 1000) {
-                            val = (val * 0.1).toFixed(0) + " milliseconds"
+                            val = (val / 1000).toFixed(0) + " milliseconds"
                         } else {
-                            val = (val * 0.01).toFixed(0) + " microseconds"
+                            val = (val).toFixed(0) + " microseconds"
                         }
                         return `<div class="chartmarker"><span>Response Time: </span><span class="font-3">${val}</span><span>${dt}</span></div>`
                     },


### PR DESCRIPTION
Time is being sent to frontend as microseconds, correctly convert those to milliseconds or leave as microseconds if too low.

Fixes #530 and fixes #534