### PR TITLE
Add support for password-manager on login form

### DIFF
--- a/frontend/src/forms/Login.vue
+++ b/frontend/src/forms/Login.vue
@@ -4,13 +4,13 @@
         <div class="form-group row">
             <label for="username" class="col-sm-2 col-form-label">{{$t('username')}}</label>
             <div class="col-sm-10">
-                <input @keyup="checkForm" type="text" v-model="username" name="username" class="form-control" id="username" placeholder="Username" autocorrect="off" autocapitalize="none">
+                <input @change="checkForm" type="text" v-model="username" name="username" class="form-control" id="username" placeholder="Username" autocorrect="off" autocapitalize="none">
             </div>
         </div>
         <div class="form-group row">
             <label for="password" class="col-sm-2 col-form-label">{{$t('password')}}</label>
             <div class="col-sm-10">
-                <input @keyup="checkForm" type="password" v-model="password" name="password" class="form-control" id="password" placeholder="Password">
+                <input @change="checkForm" type="password" v-model="password" name="password" class="form-control" id="password" placeholder="Password">
             </div>
         </div>
         <div class="form-group row">


### PR DESCRIPTION
**Current behaviour:** if the login form is _not_ filled via keyboard but with any kind of password-manager-browser-plugin (like [Lastpass](https://www.lastpass.com) or [Bitwarden](https://bitwarden.com/)) the login button stays disabled.

**Expected behaviour:** if both username and password is filled, the login button gets enabled (no matter where the input came from)