### PR TITLE
Add missing response status code

### DIFF
--- a/handlers/middleware.go
+++ b/handlers/middleware.go
@@ -161,6 +161,7 @@ func cached(duration, contentType string, handler func(w http.ResponseWriter, r 
 				w.Write(content)
 				return
 			}
+			w.WriteHeader(result.StatusCode)
 			w.Write(content)
 			if d, err := time.ParseDuration(duration); err == nil {
 				go CacheStorage.Set(r.RequestURI, content, d)


### PR DESCRIPTION
We found some Data-API can not return data source when it has been cached. So I view this middeware and find missing response status code.