### PR TITLE
[Fix - 868] add hours and day in the last_uptime

### DIFF
--- a/frontend/src/components/Service/ServiceTopStats.vue
+++ b/frontend/src/components/Service/ServiceTopStats.vue
@@ -6,11 +6,11 @@
         </div>
         <div class="col-4">
             <span class="font-5 d-block font-weight-bold">{{service.online_24_hours}} %</span>
-            <span class="font-1 subtitle">{{$t('last_uptime', [24, $tc('hour', 24)])}}</span>
+            <span class="font-1 subtitle">{{$t('last_uptime', [24, $tc('hours', 24)])}}</span>
         </div>
         <div class="col-4">
             <span class="font-5 d-block font-weight-bold">{{service.online_7_days}} %</span>
-            <span class="font-1 subtitle">{{$t('last_uptime', [7, $tc('day', 7)])}}</span>
+            <span class="font-1 subtitle">{{$t('last_uptime', [7, $tc('days', 7)])}}</span>
         </div>
     </div>
 </template>

--- a/frontend/src/components/Service/ServiceTopStats.vue
+++ b/frontend/src/components/Service/ServiceTopStats.vue
@@ -6,11 +6,11 @@
         </div>
         <div class="col-4">
             <span class="font-5 d-block font-weight-bold">{{service.online_24_hours}} %</span>
-            <span class="font-1 subtitle">{{$t('last_uptime', [24, $tc('hours', 24)])}}</span>
+            <span class="font-1 subtitle">{{$t('last_uptime')}} [ 24 {{$tc('hours', 24)}} ]</span>
         </div>
         <div class="col-4">
             <span class="font-5 d-block font-weight-bold">{{service.online_7_days}} %</span>
-            <span class="font-1 subtitle">{{$t('last_uptime', [7, $tc('days', 7)])}}</span>
+            <span class="font-1 subtitle">{{$t('last_uptime')}} [ 7 {{$tc('days', 7)}} ]</span>
         </div>
     </div>
 </template>


### PR DESCRIPTION
fixes https://github.com/statping/statping/issues/868

This is how it looks - 
<img width="947" alt="Screenshot 2020-11-12 at 6 18 23 PM" src="https://user-images.githubusercontent.com/6551988/98943857-29756600-2516-11eb-9454-17aef5c62427.png">
