### PR TITLE
Proxy Corrections (#898)

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -10,7 +10,6 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
-	"net/url"
 	"os"
 	"os/exec"
 	"strconv"
@@ -211,18 +210,10 @@ func HttpRequest(endpoint, method string, contentType interface{}, headers []str
 		TLSHandshakeTimeout:   timeout,
 		Proxy:                 http.ProxyFromEnvironment,
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			// redirect all connections to host specified in url
-			addr = strings.Split(req.URL.Host, ":")[0] + addr[strings.LastIndex(addr, ":"):]
 			return dialer.DialContext(ctx, network, addr)
 		},
 	}
-	if Params.GetString("HTTP_PROXY") != "" {
-		proxyUrl, err := url.Parse(Params.GetString("HTTP_PROXY"))
-		if err != nil {
-			return nil, nil, err
-		}
-		transport.Proxy = http.ProxyURL(proxyUrl)
-	}
+
 	if customTLS != nil {
 		transport.TLSClientConfig.RootCAs = customTLS.RootCAs
 		transport.TLSClientConfig.Certificates = customTLS.Certificates


### PR DESCRIPTION
Corrections for Bugs mentioned in #898 

Removes Host manipulation, since it breaks Proxy functionality completely. Functionality is already given by the Transport library, which handles Environment Proxy Settings:

-  https://golang.org/src/net/http/transport.go?h=addr#L1793

Removed Proxy Overwrite, Since check is not really necessary and breaks NO_PROXY options (also given by Transport).

For more information or whatever feel free to comment and take a look at the referenced issue.

