### PR TITLE
Allow statping to be executed with restricted scc, not only root

### DIFF
--- a/utils/utils_custom.go
+++ b/utils/utils_custom.go
@@ -31,7 +31,7 @@ func DirWritable(path string) (bool, error) {
 		return false, errors.New("unable to get stat")
 	}
 
-	if uint32(os.Geteuid()) != stat.Uid {
+	if uint32(os.Getgid()) != stat.Gid && uint32(os.Geteuid()) != stat.Uid {
 		return false, errors.New("user doesn't have permission to write to this directory")
 	}
 	return true, nil


### PR DESCRIPTION
This patch will allow systems like OpenShift to execute Statping with non-root users (concretely `restricted` scc).

Given a persistent volume under `/app` , this persistent volume has `gid = 0`, which is the same gid that the non-root user has, and it is whom is executing the application. This prevents Statping from going to setup every time there is a re-deploy of the application, being able to re-load the configuration under the  `/app` persistent volume, and not throwing the error `user doesn't have permission to write to this directory`.