### PR TITLE
fix: log search error

### DIFF
--- a/frontend/src/pages/Logs.vue
+++ b/frontend/src/pages/Logs.vue
@@ -61,7 +61,7 @@ export default {
           const ts = data.match(/[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1]) (2[0-3]|[01][0-9]):[0-5][0-9]:[0-5][0-9]/gm)
           return {
             time: ts[0],
-            message: data.split(ts+": ")[1]
+            message: data.split(ts+": ")[1] || ''
           }
         },
         cleanLog(l) {


### PR DESCRIPTION
# Bug

It's happened when search logs:

vendor.chunk.js:formatted:929 TypeError: Cannot read properties of undefined (reading 'includes')
    at dashboard.chunk.js:formatted:2308:42
    at Array.filter (<anonymous>)
    at o.logs (dashboard.chunk.js:formatted:2307:59)
    at hn.get (vendor.chunk.js:formatted:1776:37)
    at hn.evaluate (vendor.chunk.js:formatted:1847:35)
    at o.logs (vendor.chunk.js:formatted:1896:45)
    at o.<anonymous> (dashboard.chunk.js:formatted:2436:25)
    at o.t._render (vendor.chunk.js:formatted:2245:31)
    at o.hn.before (vendor.chunk.js:formatted:3675:37)
    at hn.get (vendor.chunk.js:formatted:1776:37)

# Root Cause

When log message is `undefined`, the code is still push the message to the `logs_record` array. and this method will call `.includes` on the message which is `undefined`. then cause crash.
```
logs() {
        if (this.search) {
          return this.logs_record.filter(o => o.message.includes(this.search));
        } else {
          return this.logs_record
        }
      }
```